### PR TITLE
Update minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.21)
 
 project(scheduling VERSION 0.1.0.0)
 


### PR DESCRIPTION
* Set the minimum CMake version to 3.21 because PROJECT_IS_TOP_LEVEL is used in the CMake scripts.