### PR TITLE
Move `index_` to scheduling.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,27 @@ option(BUILD_DOCS "Build documentation" ${PROJECT_IS_TOP_LEVEL})
 option(BUILD_TESTS "Build tests" ${PROJECT_IS_TOP_LEVEL})
 cmake_dependent_option(BUILD_TASKFLOW_BENCHMARK "Build taskflow benchmark" ${PROJECT_IS_TOP_LEVEL} "BUILD_BENCHMARKS" OFF)
 
-add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}
+  include/scheduling/scheduling.h
+  src/scheduling.cpp
+)
 
 target_include_directories(${PROJECT_NAME}
-  INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  PUBLIC
+  include
 )
+
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+  SCHEDULING_LIBRARY
+)
+
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(${PROJECT_NAME}
+    PUBLIC
+    SCHEDULING_SHARED_LIBRARY
+  )
+endif()
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include DESTINATION .)
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 ![Standard](https://img.shields.io/badge/C%2B%2B-20-blue)
 [![Build](https://github.com/dpuyda/scheduling/actions/workflows/build.yml/badge.svg)](https://github.com/dpuyda/scheduling/actions/workflows/build.yml)
 
-Scheduling is a simple, minimalistic and fast header-only library allowing you
-to run async tasks and execute task graphs.
+Scheduling is a simple, minimalistic and fast library allowing you to run async
+tasks and execute task graphs.
 
-Scheduling is developed with simplicity and performance in mind. The source code
-of Scheduling is less than 500 lines.
+Scheduling is developed with simplicity and performance in mind.
 
 * [Examples](#examples)
     * [Add Scheduling to your project](#add-scheduling-to-your-project)

--- a/src/scheduling.cpp
+++ b/src/scheduling.cpp
@@ -1,0 +1,5 @@
+#include "scheduling/scheduling.h"
+
+namespace scheduling {
+thread_local unsigned ThreadPool::index_{0};
+}  // namespace scheduling

--- a/tests/thread_pool_test.cpp
+++ b/tests/thread_pool_test.cpp
@@ -1,5 +1,5 @@
-#include "gtest/gtest.h"
-#include "scheduling/scheduling.h"
+#include <gtest/gtest.h>
+#include <scheduling/scheduling.h>
 
 namespace {
 using namespace scheduling;


### PR DESCRIPTION
* Move `index_` to scheduling.cpp to avoid possible ODR violations.
* Minor code improvements in scheduling.h.