### PR TITLE
Minor bug fixing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,19 @@ project(scheduling VERSION 0.1.0.0 LANGUAGES CXX)
 
 include(CMakeDependentOption)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 20)
+endif()
+
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(BUILD_BENCHMARKS "Build benchmarks" ${PROJECT_IS_TOP_LEVEL})
 option(BUILD_DOCS "Build documentation" ${PROJECT_IS_TOP_LEVEL})
 option(BUILD_TESTS "Build tests" ${PROJECT_IS_TOP_LEVEL})
-cmake_dependent_option(BUILD_TASKFLOW_BENCHMARK "Build taskflow benchmark" ${PROJECT_IS_TOP_LEVEL} "BUILD_BENCHMARKS" OFF)
+
+cmake_dependent_option(BUILD_TASKFLOW_BENCHMARK
+  "Build taskflow benchmark" ${PROJECT_IS_TOP_LEVEL} "BUILD_BENCHMARKS" OFF
+)
 
 add_library(${PROJECT_NAME}
   include/scheduling/scheduling.hpp

--- a/include/scheduling/scheduling.hpp
+++ b/include/scheduling/scheduling.hpp
@@ -394,8 +394,8 @@ class SCHEDULING_API ThreadPool {
    * \param task The task to execute.
    */
   void Submit(Task* task) {
-    queues_[index_].Push(task);
     ++tasks_count_;
+    queues_[index_].Push(task);
     tasks_count_.notify_one();
   }
 

--- a/tests/thread_pool_test.cpp
+++ b/tests/thread_pool_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <scheduling/scheduling.hpp>
 
 namespace {
@@ -40,7 +41,7 @@ void MatrixMultiplication(const int n, std::vector<std::vector<int>>& a,
 
   for (int i = 0; i < n; ++i) {
     tasks
-        .emplace_back([&, i] {
+        .emplace_back([&, i, n] {
           for (int j = 0; j < n; ++j) {
             a[i][j] = i + j;
           }
@@ -50,7 +51,7 @@ void MatrixMultiplication(const int n, std::vector<std::vector<int>>& a,
 
   for (int i = 0; i < n; ++i) {
     tasks
-        .emplace_back([&, i] {
+        .emplace_back([&, i, n] {
           for (int j = 0; j < n; ++j) {
             b[i][j] = i * j;
           }
@@ -60,7 +61,7 @@ void MatrixMultiplication(const int n, std::vector<std::vector<int>>& a,
 
   for (int i = 0; i < n; ++i) {
     tasks
-        .emplace_back([&, i] {
+        .emplace_back([&, i, n] {
           for (int j = 0; j < n; ++j) {
             c[i][j] = 0;
           }
@@ -70,7 +71,7 @@ void MatrixMultiplication(const int n, std::vector<std::vector<int>>& a,
 
   for (int i = 0; i < n; ++i) {
     tasks
-        .emplace_back([&, i] {
+        .emplace_back([&, i, n] {
           for (int j = 0; j < n; ++j) {
             for (int k = 0; k < n; ++k) {
               c[i][j] += a[i][k] * b[k][j];


### PR DESCRIPTION
* In `ThreadPool::Submit`, increment `tasks_count_` before pushing a task.
* In thread_pool_test.cpp, in `MatrixMultiplication`, capture `n`.
* Set CMAKE_CXX_STANDARD only if it is not set by someone else.