### PR TITLE
Optimize stop_.test()

### DIFF
--- a/include/scheduling/scheduling.hpp
+++ b/include/scheduling/scheduling.hpp
@@ -525,12 +525,11 @@ class SCHEDULING_API ThreadPool {
       if (constexpr auto max_attempts = 100; ++attempts > max_attempts) {
         tasks_count_.wait(0);
       }
-      if (stop_.test()) {
-        return;
-      }
       if (auto* task = GetTask()) {
         Execute(task);
         attempts = 0;
+      } else if (stop_.test()) {
+        return;
       }
     }
   }


### PR DESCRIPTION
* The `stop_` flag is only set in the destructor of the `ThreadPool` class. In `ThreadPool::Run`, we can check if it is set only if the task is not popped from the queue, removing `stop_.test()` from the hot path.