### PR TITLE
Disable dynamic linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,7 @@ target_compile_definitions(${PROJECT_NAME}
 )
 
 if (BUILD_SHARED_LIBS)
-  target_compile_definitions(${PROJECT_NAME}
-    PUBLIC
-    SCHEDULING_SHARED_LIBRARY
-  )
+  message(WARNING "Scheduling does not support dynamic linking.")
 endif()
 
 if (SCHEDULING_BUILD_BENCHMARKS)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Then, link Scheduling to your target. For example:
 target_link_libraries(${PROJECT_NAME} PRIVATE scheduling)
 ```
 
+> [!NOTE]  
+> Because of the use of thread-local variables, Scheduling does not support
+> dynamic linking.
+
 ## Run async tasks
 
 To run async tasks, create a `ThreadPool` instance. For example:
@@ -132,22 +136,18 @@ Add elements to `tasks`. For example, add tasks to calculate the value of
 int a, b, c, d;
 
 auto& get_a = tasks.emplace_back([&] {
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   a = 1;
 });
 
 auto& get_b = tasks.emplace_back([&] {
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   b = 2;
 });
 
 auto& get_c = tasks.emplace_back([&] {
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   c = 3;
 });
 
 auto& get_d = tasks.emplace_back([&] {
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   d = 4;
 });
 ```
@@ -156,12 +156,10 @@ Next, add tasks to calculate `a + b` and `c + d`:
 int sum_ab, sum_cd;
 
 auto& get_sum_ab = tasks.emplace_back([&] {
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   sum_ab = a + b;
 });
 
 auto& get_sum_cd = tasks.emplace_back([&] {
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   sum_cd = c + d;
 });
 ```
@@ -170,7 +168,6 @@ Finally, add the task to calculate the product `(a + b) * (c + d)`:
 int product;
 
 auto& get_product = tasks.emplace_back([&] {
-  std::this_thread::sleep_for(std::chrono::seconds(1));
   product = sum_ab * sum_cd;
 });
 ```

--- a/benchmarks/taskflow.cmake
+++ b/benchmarks/taskflow.cmake
@@ -15,7 +15,7 @@ file(WRITE "${TASKFLOW_DOWNLOAD_DIR}/CMakeLists.txt"
   project(taskflow-download CXX)
   ExternalProject_Add(taskflow-download
     GIT_REPOSITORY https://github.com/taskflow/taskflow.git
-    GIT_TAG master
+    GIT_TAG v3.7.0
     GIT_SHALLOW 1
     SOURCE_DIR \"${TASKFLOW_SRC_DIR}\"
     BINARY_DIR \"${TASKFLOW_BUILD_DIR}\"

--- a/include/scheduling/scheduling.hpp
+++ b/include/scheduling/scheduling.hpp
@@ -20,27 +20,6 @@
 #include <thread>
 #include <vector>
 
-#if defined(_MSC_VER)
-#define SCHEDULING_EXPORT __declspec(dllexport)
-#define SCHEDULING_IMPORT __declspec(dllimport)
-#elif defined(__GNUC__) || defined(__clang__)
-#define SCHEDULING_EXPORT __attribute__((visibility("default")))
-#define SCHEDULING_IMPORT
-#else
-#define SCHEDULING_EXPORT
-#define SCHEDULING_IMPORT
-#endif
-
-#ifdef SCHEDULING_SHARED_LIBRARY
-#ifdef SCHEDULING_LIBRARY
-#define SCHEDULING_API SCHEDULING_EXPORT
-#else
-#define SCHEDULING_API SCHEDULING_IMPORT
-#endif
-#else
-#define SCHEDULING_API
-#endif
-
 namespace scheduling {
 namespace internal {
 constexpr auto kCancelled = 1;
@@ -234,7 +213,7 @@ class WorkStealingDeque {
  * Dependencies between tasks define the order in which the tasks should be
  * executed.
  */
-class SCHEDULING_API Task {
+class Task {
  public:
   /**
    * \brief Creates an empty task.
@@ -385,7 +364,7 @@ class SCHEDULING_API Task {
  * The threads, managed by the thread pool, execute tasks in a work-stealing
  * manner.
  */
-class SCHEDULING_API ThreadPool {
+class ThreadPool {
  public:
   /**
    * \brief Creates a `ThreadPool` instance.


### PR DESCRIPTION
* Because of the use of thread-local variables, Scheduling does not support dynamic linking.